### PR TITLE
feat: add not found page

### DIFF
--- a/app/__tests__/not-found.test.tsx
+++ b/app/__tests__/not-found.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import NotFound from '../not-found';
+
+describe('NotFound component', () => {
+  test('renders not found message and link button', () => {
+    render(<NotFound />);
+
+    const headingElement = screen.getByTestId('not-found-heading');
+    expect(headingElement).toBeInTheDocument();
+    expect(headingElement).toHaveTextContent('Not Found');
+
+    const descriptionElement = screen.getByTestId('not-found-description');
+    expect(descriptionElement).toBeInTheDocument();
+    expect(descriptionElement).toHaveTextContent(
+      'Could not find requested resource!'
+    );
+
+    const linkButtonElement = screen.getByTestId('link-button');
+    expect(linkButtonElement).toBeInTheDocument();
+    expect(linkButtonElement).toHaveTextContent('Go home');
+    expect(linkButtonElement).toHaveAttribute('href', '/');
+  });
+});

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,20 @@
+import { LinkButton } from '@/components';
+
+export default function NotFound() {
+  return (
+    <div
+      className='p-8 my-8 mx-auto flex flex-col gap-2 min-h-full'
+      data-testid='not-found'
+    >
+      <h2 className='font-bold text-lg' data-testid='not-found-heading'>
+        Not Found
+      </h2>
+      <p className='text-gray-900' data-testid='not-found-description'>
+        Could not find requested resource!
+      </p>
+      <div className='w-48 my-4'>
+        <LinkButton btnType='secondary' label='Go home' url='/' />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
The not-found file is used to render ui when wrong route is called. It also returns a 404 http status code.